### PR TITLE
Remove sig slider

### DIFF
--- a/_includes/sigs-carousel.html
+++ b/_includes/sigs-carousel.html
@@ -1,77 +1,19 @@
-<div class="owl-carousel owl-drag owl-theme">
-  {% for sig in site.data.sigs %}
-    {% if sig.url %}
-      {% assign sighref = sig.url %}
-    {% else %}
-      {% capture sighref %} {{ site.baseurl }}/sigs/{{ sig.slug }} {% endcapture %}
-    {% endif %}
-    <div class="item card sig-card">
-      <a href="{{ sighref }}" class="list-group-item-action">
-        <h1>{{ sig.title }}</h1>
-        <p>{{ sig.description }}</p>
-        {% if sig.image %}
-          <img src="{{ site.baseurl }}/static/img/sigs/{{ sig.slug }}.png" class="sig-img"
-          style="background-color: {{ sig.colour }}; border-radius: {{ sig.radius }}"/>
+<div class="sigs__grid">
+    {% for sig in site.data.sigs %}
+        {% if sig.url %}
+            {% assign sighref = sig.url %}
+        {% else %}
+            {% capture sighref %} {{ site.baseurl }}/sigs/{{ sig.slug }} {% endcapture %}
         {% endif %}
-      </a>
-    </div>
-  {% endfor %}
+    <a href="{{ sighref }}" class="sigs__sig">
+        <div class="sigs__sigtext">
+            <h1>{{ sig.title }}</h1>
+            <p>{{ sig.description }}</p>
+        </div>
+        {% if sig.image %}
+        <img src="{{ site.baseurl }}/static/img/sigs/{{ sig.slug }}.png" class="sigs__img"
+                                                                         style="background-color: {{ sig.colour }}; border-radius: {{ sig.radius }}"/>
+        {% endif %}
+    </a>
+    {% endfor %}
 </div>
-
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script src="{{ site.baseurl }}/static/js/jquery.mousewheel.min.js"></script>
-<script src="{{ site.baseurl }}/static/js/owl.carousel.min.js"></script>
-<script>
-  var owl = $('.owl-carousel');
-  owl.owlCarousel({
-    responsiveClass:true,
-    responsive: {
-      0: {
-        center: true,
-        autoplay: false,
-        items: 1,
-      },
-      400: {
-        center: true,
-        autoplay: false,
-        items: 1.5,
-      },
-      576: {
-        center: true,
-        autoplay: false,
-        items: 2,
-      },
-      768: {
-        center: true,
-        autoplay: false,
-        items: 3,
-      },
-      992: {
-        center: true,
-        autoplay: false,
-        items: 4,
-      },
-      1200: {
-        autoWidth: true,
-        margin: 10,
-        rewind: true,
-        autoplay: true,
-        autoplayTimeout: 4000,
-        autoplayHoverPause: true,
-        navSpeed: 200,
-        smartSpeed: 1500,
-        dragEndSpeed: 200,
-      },
-      dots: true,
-      responsiveRefreshRate: 100,
-    },
-  });
-  owl.on('mousewheel', '.owl-stage', function (e) {
-    if (e.deltaY > 0) {
-        owl.trigger('next.owl');
-    } else {
-        owl.trigger('prev.owl');
-    }
-    e.preventDefault();
-  });
-</script>

--- a/_sass/_sigs.sass
+++ b/_sass/_sigs.sass
@@ -1,32 +1,55 @@
-.sigs-item
-    width: 200px
-    height: 250px
-    text-align: center
-    margin-right: 1rem
-    margin-bottom: 1rem
+@import 'utils'
 
-.sigint-logo-community
-    border-radius: 50%
-    padding-top: 0px
-    width: 25%
-    background-color: #333333
-    margin-right: 10px
-    max-width: 100px
+.sigs__grid
+    display: grid
 
-.sig-card
-    margin: auto
+    grid-gap: 2px
+
+    // mobile: 3 rows, 2 cols
+    grid-template-rows: 1fr 1fr 1fr
+    grid-template-columns: 1fr 1fr
+    
+    // desktop: 2 rows, 3 cols
+    @media (min-width: 1000px)
+        grid-template-rows: 1fr 1fr
+        grid-template-columns: 1fr 1fr 1fr
+
+    // smaller mobile devices: 1 column, N rows
+    @media (max-width: 400px)
+        grid-template-rows: repeat(1fr)
+        grid-template-columns: 1fr
+
+
+
+
+.sigs__img
+    width: 100px
+    height: 100px
+    margin: 10px
+
+
+.sigs__sig
+    display: flex
+    flex-direction: column
+    justify-content: space-between
+    align-items: center
+    @include media-desktop
+        flex-direction: row
+    padding: 10px
+    
+    text-decoration: none !important
+    color: black
+    background-color: #F9F9F9
+
+    &:hover
+        background-color: white
+
+
+.sigs__sigtext
     text-align: center
-    width: 200px
-    height: 250px
-    a
-        padding: 10px
-        width: 100%
-        height: 100%
-        text-decoration: none
-    p
-        height: 40px
-    .sig-img
-        margin: 20px auto
-        vertical-align: middle
-        width: 100px !important
-        padding: 10px
+    @include media-desktop
+        text-align: left
+
+
+
+

--- a/_sass/_utils.sass
+++ b/_sass/_utils.sass
@@ -1,0 +1,7 @@
+@mixin media-desktop
+    @media (min-width: 768px)
+        @content
+
+@mixin media-mobile
+    @media (max-width: 768px)
+        @content


### PR DESCRIPTION
...and replace with a nice responsive css grid that doesn't freak out when you scroll on it. And also be able to show all the sigs at once.

<img width="1065" alt="Screen Shot 2019-10-17 at 1 52 34 PM" src="https://user-images.githubusercontent.com/6288183/67010489-a224ab80-f0e5-11e9-8e14-21526fddc27b.png">

_just making a pr for hacktoberfest tbh_