### PR TITLE
fix the sig css on desktop sizes

### DIFF
--- a/_sass/_sigs.sass
+++ b/_sass/_sigs.sass
@@ -11,11 +11,11 @@
     
     // desktop: 2 rows, 3 cols
     @media (min-width: 1000px)
-        grid-template-rows: 1fr 1fr
-        grid-template-columns: 1fr 1fr 1fr
+        grid-template-rows: 1fr 1fr 1fr 1fr
+        grid-template-columns: 1fr 1fr
 
     // smaller mobile devices: 1 column, N rows
-    @media (max-width: 400px)
+    @media (max-width: 1000px)
         grid-template-rows: repeat(1fr)
         grid-template-columns: 1fr
 


### PR DESCRIPTION
<img width="1244" alt="Screen Shot 2020-10-28 at 1 46 59 PM" src="https://user-images.githubusercontent.com/6288183/97475888-2bd79d80-1924-11eb-8b91-ea5fe2c28307.png">

Basically, just fix the sig grid so it no longer overflows at certain sizes. This makes the sig grid 2 columns—3 col was difficult to stop from overflowing across different breakpoints.