### PR TITLE
Fix EUSA links following their website renewal

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -26,7 +26,7 @@ custom_css:
         <a class="btn btn-primary btn-lg btn-success mb-2" href="{{ site.baseurl }}/events" role="button">View our events</a>
         <a class="btn btn-primary btn-lg btn-info mb-2" href="{{ site.baseurl }}/community" role="button">Meet the community</a>
         <a class="btn btn-primary btn-lg btn-discord mb-2" href="{{ site.baseurl }}/chat" role="button">Join our Discord</a>
-        <a class="btn btn-primary btn-lg btn-danger mb-2" href="https://www.eusa.ed.ac.uk/activities/societies/society/compsoc/" role="button">Become a member</a>
+        <a class="btn btn-primary btn-lg btn-danger mb-2" href="https://www.eusa.ed.ac.uk/activities/view/compsoc" role="button">Become a member</a>
     </p>
 
     <p>

--- a/_pages/join.md
+++ b/_pages/join.md
@@ -1,7 +1,7 @@
 ---
 title: Join
 permalink: /join
-redirect: https://www.eusa.ed.ac.uk/activities/societies/society/compsoc/
+redirect: https://www.eusa.ed.ac.uk/activities/view/compsoc
 ---
 
 Redirecting...


### PR DESCRIPTION
EUSA has changed their website in the last year, and links to our society page on EUSA no longer work. This pull request fixes all the links in _index.html and _join.html.

It was confirmed via a grep that no crucial pages remain unfixed. There are several _posts that still have old links, but those were deliberately unaltered to preserve the original state.
```
$ grep -r "eusa.ed.ac.uk/activities/societies" .
```