### PR TITLE
Update Vice President following new appointment

### DIFF
--- a/_data/committee/2021-2022.yml
+++ b/_data/committee/2021-2022.yml
@@ -6,7 +6,7 @@ teams:
         # url:
         # img:
 
-      - name: Bence Szilagyi
+      - name: Oscar Shrimpton
         role: Vice President
       #   url:
       #   img:


### PR DESCRIPTION
Remove the resigned previous vice president and added in the newly appointed vice president. Images and links are not filled, although committee members are encouraged to upload or edit to include their own.

Tested locally with Docker.