### PR TITLE
Add Committee as a CODEOWNER for /_posts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *           @compsoc-edinburgh/sigweb
 /_minutes/  @compsoc-edinburgh/committee
+/_posts/    @compsoc-edinburgh/committee


### PR DESCRIPTION
The Posts/News section of the CompSoc website is used for updates and announcements by the committee currently in charge. I think it makes sense for the Committee GitHub team to have write access to these posts in addition to the minutes.