### PR TITLE
Fix LaTeX formatting for the minutes dated 03/11/22

### DIFF
--- a/_minutes/2022-11-03.md
+++ b/_minutes/2022-11-03.md
@@ -4,7 +4,7 @@ date: 03/11/2022
 
 # Call to Order
 
-This meeting took place at $17:05$ on the $3$^rd^ of November, lead by
+This meeting took place at 17:05 on the 3rd of November, lead by
 president Ben McConville.
 
 # Sederunt
@@ -12,7 +12,7 @@ president Ben McConville.
 ## Following up on Last Meeting's Minutes
 
 Going over HackTheBurgh, Ben was supposed to have a meeting today but
-she didn't turn up, hoping to hear back soon. October 25^th^ STMU,
+she didn't turn up, hoping to hear back soon. October 25th STMU,
 expenses were £130 for food, £15 for soft drinks, Secretary handover has
 been complete. Prepare November 13th STMU Talk \[name tbd.\]. Normal
 person for STMU isn't there but maybe find someone else who is already
@@ -52,10 +52,10 @@ main venue has always been available.
 ## Upcoming Social Events
 
 **Event 1:** CompSoc watching the fireworks show at Calton Hill on the
-5^th^. Meeting at 7:30 at AT or 8:00 ontop of Calton Hill. Everyone will
+5th. Meeting at 7:30 at AT or 8:00 ontop of Calton Hill. Everyone will
 go to Teviot after.
 
-**Event 2:** November STMU on the 13^th^. Give out the last of old
+**Event 2:** November STMU on the 30th. Give out the last of old
 CompSoc merch at STMU. Dylan and Accenture are doing talks at the STMU.
 Information unknown currently.\
 **Event 3:** CompSoc Christmas Market. Planning for CompSoc to meetup
@@ -77,5 +77,5 @@ and travel around this year's Christmas Market.
 
 # Adjournment
 
-Ben adjourns the meeting at $17:54$.\
+Ben adjourns the meeting at 17:54.\
 Minutes taken by: Maya Copeland


### PR DESCRIPTION
When converting from latex to markdown, it seems to have messed with the $$ in Markdown, this fixes it for the minutes from 03/11/22