### PR TITLE
Fix LaTeX formatting for minutes dated 10/11/22

### DIFF
--- a/_minutes/2022-11-10.md
+++ b/_minutes/2022-11-10.md
@@ -4,7 +4,7 @@ date: 10/11/2022
 
 # Call to Order
 
-This meeting took place at $17:00$ on the $10$^th^ of November, lead by
+This meeting took place at 17:00 on the 10th of November, lead by
 president Ben McConville.
 
 # Sederunt
@@ -47,7 +47,7 @@ SDP aren't working as they are easily forgotten.
 
 ## Upcoming Social Events
 
-**Event 2:** November STMU on the 13^th^. Give out the last of old
+**Event 2:** November STMU on the 30th. Give out the last of old
 CompSoc merch at STMU. Dylan and Accenture are doing talks at the STMU. Information has been given now \
 **Event 3:** CompSoc Christmas Market. Planning for CompSoc to meetup
 and travel around this year's Christmas Market.
@@ -74,5 +74,5 @@ and travel around this year's Christmas Market.
 
 # Adjournment
 
-Ben McConville adjourns the meeting at $18:02$.\
+Ben McConville adjourns the meeting at 18:02.\
 Minutes taken by: Maya Copeland


### PR DESCRIPTION
Similar to the other PR, this gets rid of the latex $$ formatting for times and dates.