### PR TITLE
Update TypeSig URL to main website

### DIFF
--- a/_data/sigs.yml
+++ b/_data/sigs.yml
@@ -30,6 +30,7 @@
 
 - title: TypeSig
   description: Type Theory and related fields
+  url: https://typesig.comp-soc.com/
   slug: typesig
   image: true
   colour: '#fff'


### PR DESCRIPTION
TypeSig now have their own subdomain, so let's change the URL on the main CompSoc website.